### PR TITLE
Add service and pod monitor relabeling back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ServiceMonitor` and `PodMonitor` default relabelling.
+
 ## [0.0.1] - 2022-03-31
 
 ### Added

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Giant Swarm CRDs
-kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/giantswarm/apiextensions/15836a106059cc8d201e1237adf44aec340bbab6/helm/crds-common/templates/giantswarm.yaml -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
+kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/giantswarm/apiextensions/15836a106059cc8d201e1237adf44aec340bbab6/helm/crds-common/templates/giantswarm.yaml -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.56.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.56.2/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 
 MOCK_CREDENTIALS=$(echo -n "something" | base64)
 

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Giant Swarm CRDs
-kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/giantswarm/apiextensions/15836a106059cc8d201e1237adf44aec340bbab6/helm/crds-common/templates/giantswarm.yaml
+kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/giantswarm/apiextensions/15836a106059cc8d201e1237adf44aec340bbab6/helm/crds-common/templates/giantswarm.yaml -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
 
 MOCK_CREDENTIALS=$(echo -n "something" | base64)
 

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -34,7 +34,13 @@ spec:
                   targetLabel: node
                 - sourceLabels: [__meta_kubernetes_node_label_role]
                   targetLabel: role
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  regex: ""
-                  targetLabel: role
-                  replacement: "worker"
+                - replacement: "{{ .Values.managementCluster.customer }}"
+                  targetLabel: customer
+                ## We get the organization from the namespace (org-organization_name)
+                - replacement: "{{ `{{` }} request.namespace {{ `}}` }}" 
+                  targetLabel: organization
+                ## Then we remove the org prefix
+                - sourceLabels: [organization]
+                  regex: org-(.*)
+                  replacement: "${1}"
+                  targetLabel: organization

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -1,0 +1,40 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: configure-pod-monitor-labelling-schema
+spec:
+  rules:
+    - name: configure-pod-monitor-labelling-schema
+      match:
+        resources:
+          kinds:
+          - monitoring.coreos.com/v1/PodMonitor
+      mutate:
+        patchStrategicMerge:
+          spec:
+            podMetricsEndpoints:
+              - relabelings:
+                  # Pod Monitors are currently only supported on management clusters so we can enforce the cluster_id and cluster_type.
+                - replacement: "{{ .Values.managementCluster.name }}"
+                  targetLabel: cluster_id
+                - replacement: "management_cluster"
+                  targetLabel: cluster_type
+                - replacement: "{{ .Values.provider.kind }}"
+                  targetLabel: provider
+                - replacement: "{{ .Values.managementCluster.name }}"
+                  targetLabel: installation
+                - sourceLabels: [__meta_kubernetes_namespace]
+                  targetLabel: namespace
+                - sourceLabels: [__meta_kubernetes_pod_name]
+                  targetLabel: pod
+                - sourceLabels: [__meta_kubernetes_pod_container_name]
+                  targetLabel: container
+                - sourceLabels: [__meta_kubernetes_pod_node_name]
+                  targetLabel: node
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  targetLabel: role
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  regex: ""
+                  targetLabel: role
+                  replacement: "worker"

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -1,0 +1,40 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: configure-service-monitor-labelling-schema
+spec:
+  rules:
+    - name: configure-service-monitor-labelling-schema
+      match:
+        resources:
+          kinds:
+          - monitoring.coreos.com/v1/ServiceMonitor
+      mutate:
+        patchStrategicMerge:
+          spec:
+            endpoints:
+              - relabelings:
+                  # Service Monitors are currently only supported on management clusters so we can enforce the cluster_id and cluster_type.
+                - replacement: "{{ .Values.managementCluster.name }}"
+                  targetLabel: cluster_id
+                - replacement: "management_cluster"
+                  targetLabel: cluster_type
+                - replacement: "{{ .Values.provider.kind }}"
+                  targetLabel: provider
+                - replacement: "{{ .Values.managementCluster.name }}"
+                  targetLabel: installation
+                - sourceLabels: [__meta_kubernetes_namespace]
+                  targetLabel: namespace
+                - sourceLabels: [__meta_kubernetes_pod_name]
+                  targetLabel: pod
+                - sourceLabels: [__meta_kubernetes_pod_container_name]
+                  targetLabel: container
+                - sourceLabels: [__meta_kubernetes_pod_node_name]
+                  targetLabel: node
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  targetLabel: role
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  regex: ""
+                  targetLabel: role
+                  replacement: "worker"

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -34,7 +34,13 @@ spec:
                   targetLabel: node
                 - sourceLabels: [__meta_kubernetes_node_label_role]
                   targetLabel: role
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  regex: ""
-                  targetLabel: role
-                  replacement: "worker"
+                - replacement: "{{ .Values.managementCluster.customer }}"
+                  targetLabel: customer
+                ## We get the organization from the namespace (org-organization_name)
+                - replacement: "{{ `{{` }} request.namespace {{ `}}` }}" 
+                  targetLabel: organization
+                ## Then we remove the org prefix
+                - sourceLabels: [organization]
+                  regex: org-(.*)
+                  replacement: "${1}"
+                  targetLabel: organization

--- a/helm/kyverno-policies-observability/tests/ats/test_common_default.py
+++ b/helm/kyverno-policies-observability/tests/ats/test_common_default.py
@@ -21,6 +21,10 @@ from ensure import kubeadm_control_plane
 from ensure import kubeadmconfig_controlplane
 from ensure import kubeadmconfig_with_files
 from ensure import kubeadmconfig_with_audit_file
+from ensure import podmonitor
+from ensure import silence
+from ensure import silence_with_matchers
+from ensure import servicemonitor
 
 import pytest
 from pytest_kube import forward_requests, wait_for_rollout, app_template
@@ -60,3 +64,75 @@ def test_kubeadmconfig_auditpolicy(kubeadmconfig_with_audit_file) -> None:
     :param kubeadmconfig_with_audit_file: KubeadmConfig CR which includes an existing audit file
     """
     assert len(kubeadmconfig_with_audit_file['spec']['files']) == 1
+
+
+@pytest.mark.smoke
+def test_silence_heartbeat_policy(silence) -> None:
+    """
+    test_silence_heartbeat_policy tests defaulting of an empty Silence to check for the negative Heartbeat matcher.
+    :param silence: Any Silence CR.
+    """
+    matchers = silence['spec']['matchers']
+
+    for matcher in matchers:
+        if matcher['name'] == "alertname":
+            assert (matcher['value'] == "Heartbeat" and not matcher['isRegex'] and not matcher['isEqual'])
+            return
+
+    pytest.fail("Heartbeat matcher is missing")
+
+@pytest.mark.smoke
+def test_silence_heartbeat_policy_with_existing_matchers(silence_with_matchers) -> None:
+    """
+    test_silence_heartbeat_policy tests defaulting of a Silence container a matcher to check for the negative Heartbeat matcher.
+    :param silence_with_matchers: Any Silence CR container a matcher.
+    """
+    matchers = silence_with_matchers['spec']['matchers']
+
+    assert (matchers[0]['value'] == "test" and matchers[0]['name'] == "test" and not matchers[0]['isRegex'] and not matchers[0]['isEqual'])
+    assert (matchers[1]['value'] == "Heartbeat" and matchers[1]['name'] == "alertname" and not matchers[1]['isRegex'] and not matchers[1]['isEqual'])
+
+
+@pytest.mark.smoke
+def test_pod_monitor_labelling_schema_policy(podmonitor) -> None:
+    """
+    test_service_monitor_labelling_schema_policy tests defaulting of an empty Service monitor to check that the labelling schema is configured.
+    :param podmonitor: Any PodMonitor CR.
+    """
+    endpoints = podmonitor['spec']['podMetricsEndpoints']
+    for endpoint in endpoints:
+        relabelings = endpoint['relabelings']
+        assert relabelings[0]['replacement'] == '' and relabelings[0]['targetLabel'] == 'cluster_id'                                      \
+          and relabelings[1]['replacement'] == 'management_cluster' and relabelings[1]['targetLabel'] == 'cluster_type'                   \
+          and relabelings[2]['replacement'] == '' and relabelings[2]['targetLabel'] == 'provider'                                         \
+          and relabelings[3]['replacement'] == '' and relabelings[3]['targetLabel'] == 'installation'                                     \
+          and relabelings[4]['sourceLabels'] == ['__meta_kubernetes_namespace'] and relabelings[4]['targetLabel'] == 'namespace'          \
+          and relabelings[5]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[5]['targetLabel'] == 'pod'                 \
+          and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[6]['targetLabel'] == 'container' \
+          and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[7]['targetLabel'] == 'node'           \
+          and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[8]['targetLabel'] == 'role'         \
+          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[9]['targetLabel'] == 'role'         \
+          and relabelings[9]['regex'] == '' and relabelings[9]['replacement'] == 'worker'                                                 \
+        , 'Invalid relabelings {}'.format(relabelings)
+
+@pytest.mark.smoke
+def test_service_monitor_labelling_schema_policy(servicemonitor) -> None:
+    """
+    test_service_monitor_labelling_schema_policy tests defaulting of an empty Service monitor to check that the labelling schema is configured.
+    :param servicemonitor: Any ServiceMonitor CR.
+    """
+    endpoints = servicemonitor['spec']['endpoints']
+    for endpoint in endpoints:
+        relabelings = endpoint['relabelings']
+        assert relabelings[0]['replacement'] == '' and relabelings[0]['targetLabel'] == 'cluster_id'                                      \
+          and relabelings[1]['replacement'] == 'management_cluster' and relabelings[1]['targetLabel'] == 'cluster_type'                   \
+          and relabelings[2]['replacement'] == '' and relabelings[2]['targetLabel'] == 'provider'                                         \
+          and relabelings[3]['replacement'] == '' and relabelings[3]['targetLabel'] == 'installation'                                     \
+          and relabelings[4]['sourceLabels'] == ['__meta_kubernetes_namespace'] and relabelings[4]['targetLabel'] == 'namespace'          \
+          and relabelings[5]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[5]['targetLabel'] == 'pod'                 \
+          and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[6]['targetLabel'] == 'container' \
+          and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[7]['targetLabel'] == 'node'           \
+          and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[8]['targetLabel'] == 'role'         \
+          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[9]['targetLabel'] == 'role'         \
+          and relabelings[9]['regex'] == '' and relabelings[9]['replacement'] == 'worker'                                                 \
+        , 'Invalid relabelings {}'.format(relabelings)

--- a/helm/kyverno-policies-observability/tests/ats/test_common_default.py
+++ b/helm/kyverno-policies-observability/tests/ats/test_common_default.py
@@ -111,9 +111,10 @@ def test_pod_monitor_labelling_schema_policy(podmonitor) -> None:
           and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[6]['targetLabel'] == 'container' \
           and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[7]['targetLabel'] == 'node'           \
           and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[8]['targetLabel'] == 'role'         \
-          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[9]['targetLabel'] == 'role'         \
-          and relabelings[9]['regex'] == '' and relabelings[9]['replacement'] == 'worker'                                                 \
-        , 'Invalid relabelings {}'.format(relabelings)
+          and relabelings[9]['replacement'] == '' and relabelings[9]['targetLabel'] == 'customer'                                         \
+          and relabelings[10]['replacement'] == 'default' and relabelings[10]['targetLabel'] == 'organization'                                   \
+          and relabelings[11]['sourceLabels'] == ['organization'] and relabelings[11]['regex'] == 'org-(.*)' and relabelings[11]['replacement'] == '${1}' and relabelings[11]['targetLabel'] == 'organization' \
+        , 'Invalid relabelings {} '.format(relabelings)
 
 @pytest.mark.smoke
 def test_service_monitor_labelling_schema_policy(servicemonitor) -> None:
@@ -133,6 +134,7 @@ def test_service_monitor_labelling_schema_policy(servicemonitor) -> None:
           and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[6]['targetLabel'] == 'container' \
           and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[7]['targetLabel'] == 'node'           \
           and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[8]['targetLabel'] == 'role'         \
-          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[9]['targetLabel'] == 'role'         \
-          and relabelings[9]['regex'] == '' and relabelings[9]['replacement'] == 'worker'                                                 \
+          and relabelings[9]['replacement'] == '' and relabelings[9]['targetLabel'] == 'customer'                                         \
+          and relabelings[10]['replacement'] == 'default' and relabelings[10]['targetLabel'] == 'organization'                                   \
+          and relabelings[11]['sourceLabels'] == ['organization'] and relabelings[11]['regex'] == 'org-(.*)' and relabelings[11]['replacement'] == '${1}' and relabelings[11]['targetLabel'] == 'organization' \
         , 'Invalid relabelings {}'.format(relabelings)

--- a/helm/kyverno-policies-observability/values.yaml
+++ b/helm/kyverno-policies-observability/values.yaml
@@ -1,0 +1,5 @@
+managementCluster:
+  name: ""
+
+provider:
+  kind: ""

--- a/helm/kyverno-policies-observability/values.yaml
+++ b/helm/kyverno-policies-observability/values.yaml
@@ -1,5 +1,6 @@
 managementCluster:
   name: ""
+  customer: ""
 
 provider:
   kind: ""

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -33,7 +33,13 @@ spec:
                   targetLabel: node
                 - sourceLabels: [__meta_kubernetes_node_label_role]
                   targetLabel: role
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  regex: ""
-                  targetLabel: role
-                  replacement: "worker"
+                - replacement: "[[ .Values.managementCluster.customer ]]"
+                  targetLabel: customer
+                ## We get the organization from the namespace (org-organization_name)
+                - replacement: "{{ request.namespace }}" 
+                  targetLabel: organization
+                ## Then we remove the org prefix
+                - sourceLabels: [organization]
+                  regex: org-(.*)
+                  replacement: "${1}"
+                  targetLabel: organization

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -1,0 +1,39 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: configure-pod-monitor-labelling-schema
+spec:
+  rules:
+    - name: configure-pod-monitor-labelling-schema
+      match:
+        resources:
+          kinds:
+          - monitoring.coreos.com/v1/PodMonitor
+      mutate:
+        patchStrategicMerge:
+          spec:
+            podMetricsEndpoints:
+              - relabelings:
+                  # Pod Monitors are currently only supported on management clusters so we can enforce the cluster_id and cluster_type.
+                - replacement: "[[ .Values.managementCluster.name ]]"
+                  targetLabel: cluster_id
+                - replacement: "management_cluster"
+                  targetLabel: cluster_type
+                - replacement: "[[ .Values.provider.kind ]]"
+                  targetLabel: provider
+                - replacement: "[[ .Values.managementCluster.name ]]"
+                  targetLabel: installation
+                - sourceLabels: [__meta_kubernetes_namespace]
+                  targetLabel: namespace
+                - sourceLabels: [__meta_kubernetes_pod_name]
+                  targetLabel: pod
+                - sourceLabels: [__meta_kubernetes_pod_container_name]
+                  targetLabel: container
+                - sourceLabels: [__meta_kubernetes_pod_node_name]
+                  targetLabel: node
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  targetLabel: role
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  regex: ""
+                  targetLabel: role
+                  replacement: "worker"

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -33,7 +33,13 @@ spec:
                   targetLabel: node
                 - sourceLabels: [__meta_kubernetes_node_label_role]
                   targetLabel: role
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  regex: ""
-                  targetLabel: role
-                  replacement: "worker"
+                - replacement: "[[ .Values.managementCluster.customer ]]"
+                  targetLabel: customer
+                ## We get the organization from the namespace (org-organization_name)
+                - replacement: "{{ request.namespace }}" 
+                  targetLabel: organization
+                ## Then we remove the org prefix
+                - sourceLabels: [organization]
+                  regex: org-(.*)
+                  replacement: "${1}"
+                  targetLabel: organization

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -1,0 +1,39 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: configure-service-monitor-labelling-schema
+spec:
+  rules:
+    - name: configure-service-monitor-labelling-schema
+      match:
+        resources:
+          kinds:
+          - monitoring.coreos.com/v1/ServiceMonitor
+      mutate:
+        patchStrategicMerge:
+          spec:
+            endpoints:
+              - relabelings:
+                  # Service Monitors are currently only supported on management clusters so we can enforce the cluster_id and cluster_type.
+                - replacement: "[[ .Values.managementCluster.name ]]"
+                  targetLabel: cluster_id
+                - replacement: "management_cluster"
+                  targetLabel: cluster_type
+                - replacement: "[[ .Values.provider.kind ]]"
+                  targetLabel: provider
+                - replacement: "[[ .Values.managementCluster.name ]]"
+                  targetLabel: installation
+                - sourceLabels: [__meta_kubernetes_namespace]
+                  targetLabel: namespace
+                - sourceLabels: [__meta_kubernetes_pod_name]
+                  targetLabel: pod
+                - sourceLabels: [__meta_kubernetes_pod_container_name]
+                  targetLabel: container
+                - sourceLabels: [__meta_kubernetes_pod_node_name]
+                  targetLabel: node
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  targetLabel: role
+                - sourceLabels: [__meta_kubernetes_node_label_role]
+                  regex: ""
+                  targetLabel: role
+                  replacement: "worker"


### PR DESCRIPTION
This PR adds the default labelling schema to podmonitor and servicemonitor policies that was removed due to an upstream bug in kyverno

### Checklist

- [x] Update changelog in CHANGELOG.md.
