### PR TITLE
Fix relabelings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - README: instructions to run local tests
-- podMonitor and serviceMoniter relabeling are added to existing config, rather than replacing it
+- podMonitor and serviceMoniter relabeling are added to existing config, rather than replacing it. Warning: that means their behavior could change!
 
 ## [0.1.3] - 2022-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - README: instructions to run local tests
+- podMonitor and serviceMoniter relabeling are added to existing config, rather than replacing it
 
 ## [0.1.3] - 2022-08-05
 

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -56,8 +56,10 @@ spec:
               op: add
               value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            # - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-            #   op: add
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              # TODO: fix request.namespace templating
+              value: {"replacement": "default", "targetLabel": "organization"}
             #   value: {"replacement": "{#{ request.namespace {{ `}}` }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -33,33 +33,33 @@ spec:
               value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+              value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
+            # - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+            #   op: add
+            #   value: {"replacement": "{#{ request.namespace {{ `}}` }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}
+              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -7,9 +7,10 @@ spec:
   rules:
     - name: configure-pod-monitor-labelling-schema
       match:
-        resources:
-          kinds:
-          - monitoring.coreos.com/v1/PodMonitor
+        any:
+        - resources:
+            kinds:
+            - monitoring.coreos.com/v1/PodMonitor
       mutate:
         foreach:
         - list: request.object.spec.podMetricsEndpoints
@@ -58,9 +59,7 @@ spec:
             ## We get the organization from the namespace (org-organization_name)
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              # TODO: fix request.namespace templating
-              value: {"replacement": "default", "targetLabel": "organization"}
-            #   value: {"replacement": "{#{ request.namespace {{ `}}` }}", "targetLabel": "organization"}
+              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -11,43 +11,55 @@ spec:
           kinds:
           - monitoring.coreos.com/v1/PodMonitor
       mutate:
-        patchStrategicMerge:
-          spec:
-            podMetricsEndpoints:
-              - relabelings:
-                  # Pod Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-                - replacement: "{{ .Values.managementCluster.name }}"
-                  targetLabel: cluster_id
-                - replacement: "management_cluster"
-                  targetLabel: cluster_type
-                  # Since we only support management clusters, all resources are considered as highest service priority
-                - replacement: "highest"
-                  targetLabel: service_priority
-                - replacement: "{{ .Values.provider.kind }}"
-                  targetLabel: provider
-                - replacement: "{{ .Values.managementCluster.name }}"
-                  targetLabel: installation
-                - sourceLabels: [__meta_kubernetes_namespace]
-                  targetLabel: namespace
-                - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
-                  targetLabel: app
-                - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
-                  targetLabel: instance
-                - sourceLabels: [__meta_kubernetes_pod_name]
-                  targetLabel: pod
-                - sourceLabels: [__meta_kubernetes_pod_container_name]
-                  targetLabel: container
-                - sourceLabels: [__meta_kubernetes_pod_node_name]
-                  targetLabel: node
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  targetLabel: role
-                - replacement: "{{ .Values.managementCluster.customer }}"
-                  targetLabel: customer
-                ## We get the organization from the namespace (org-organization_name)
-                - replacement: "{{ `{{` }} request.namespace {{ `}}` }}" 
-                  targetLabel: organization
-                ## Then we remove the org prefix
-                - sourceLabels: [organization]
-                  regex: org-(.*)
-                  replacement: "${1}"
-                  targetLabel: organization
+        foreach:
+        - list: request.object.spec.podMetricsEndpoints
+          patchesJson6902: |-
+            # Pod Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "cluster_id"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
+            # Since we only support management clusters, all resources are considered as highest service priority
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "highest", "targetLabel": "service_priority"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.provider.kind }}", "targetLabel": "provider"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
+            ## We get the organization from the namespace (org-organization_name)
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
+            ## Then we remove the org prefix
+            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -33,33 +33,33 @@ spec:
               value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+              value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
+            # - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+            #   op: add
+            #   value: {"replacement": "{#{ request.namespace {{ `}}` }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}
+              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -11,43 +11,55 @@ spec:
           kinds:
           - monitoring.coreos.com/v1/ServiceMonitor
       mutate:
-        patchStrategicMerge:
-          spec:
-            endpoints:
-              - relabelings:
-                  # Service Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-                - replacement: "{{ .Values.managementCluster.name }}"
-                  targetLabel: cluster_id
-                - replacement: "management_cluster"
-                  targetLabel: cluster_type
-                  # Since we only support management clusters, all resources are considered as highest service priority
-                - replacement: "highest"
-                  targetLabel: service_priority
-                - replacement: "{{ .Values.provider.kind }}"
-                  targetLabel: provider
-                - replacement: "{{ .Values.managementCluster.name }}"
-                  targetLabel: installation
-                - sourceLabels: [__meta_kubernetes_namespace]
-                  targetLabel: namespace
-                - sourceLabels: [ __meta_kubernetes_pod_label_app_kubernetes_io_name ]
-                  targetLabel: app
-                - sourceLabels: [ __meta_kubernetes_pod_label_app_kubernetes_io_instance ]
-                  targetLabel: instance
-                - sourceLabels: [__meta_kubernetes_pod_name]
-                  targetLabel: pod
-                - sourceLabels: [__meta_kubernetes_pod_container_name]
-                  targetLabel: container
-                - sourceLabels: [__meta_kubernetes_pod_node_name]
-                  targetLabel: node
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  targetLabel: role
-                - replacement: "{{ .Values.managementCluster.customer }}"
-                  targetLabel: customer
-                ## We get the organization from the namespace (org-organization_name)
-                - replacement: "{{ `{{` }} request.namespace {{ `}}` }}" 
-                  targetLabel: organization
-                ## Then we remove the org prefix
-                - sourceLabels: [organization]
-                  regex: org-(.*)
-                  replacement: "${1}"
-                  targetLabel: organization
+        foreach:
+        - list: request.object.spec.endpoints
+          patchesJson6902: |-
+            # Service Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "cluster_id"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
+            # Since we only support management clusters, all resources are considered as highest service priority
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "highest", "targetLabel": "service_priority"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.provider.kind }}", "targetLabel": "provider"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
+            ## We get the organization from the namespace (org-organization_name)
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
+            ## Then we remove the org prefix
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -7,9 +7,10 @@ spec:
   rules:
     - name: configure-service-monitor-labelling-schema
       match:
-        resources:
-          kinds:
-          - monitoring.coreos.com/v1/ServiceMonitor
+        any:
+        - resources:
+            kinds:
+            - monitoring.coreos.com/v1/ServiceMonitor
       mutate:
         foreach:
         - list: request.object.spec.endpoints
@@ -58,9 +59,7 @@ spec:
             ## We get the organization from the namespace (org-organization_name)
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              # TODO: fix request.namespace templating
-              value: {"replacement": "default", "targetLabel": "organization"}
-            #   value: {"replacement": "{#{ request.namespace {{ `}}` }}", "targetLabel": "organization"}
+              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -56,8 +56,10 @@ spec:
               op: add
               value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            # - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-            #   op: add
+            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
+              op: add
+              # TODO: fix request.namespace templating
+              value: {"replacement": "default", "targetLabel": "organization"}
             #   value: {"replacement": "{#{ request.namespace {{ `}}` }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"

--- a/helm/kyverno-policies-observability/tests/ats/test_common_default.py
+++ b/helm/kyverno-policies-observability/tests/ats/test_common_default.py
@@ -112,9 +112,9 @@ def test_pod_monitor_labelling_schema_policy(podmonitor) -> None:
           and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_instance'] and relabelings[7]['targetLabel'] == 'instance' \
           and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[8]['targetLabel'] == 'pod'                                  \
           and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[9]['targetLabel'] == 'container'                  \
-          and relabelings[10]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[10]['targetLabel'] == 'node'                            \
-          and relabelings[11]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[11]['targetLabel'] == 'role'                          \
-          and relabelings[12]['replacement'] == '' and relabelings[12]['targetLabel'] == 'customer'                                                          \
+          and relabelings[10]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[10]['targetLabel'] == 'node'                          \
+          and relabelings[11]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[11]['targetLabel'] == 'role'                        \
+          and relabelings[12]['replacement'] == '' and relabelings[12]['targetLabel'] == 'customer'                                                        \
           and relabelings[13]['replacement'] == 'default' and relabelings[13]['targetLabel'] == 'organization'                                             \
           and relabelings[14]['sourceLabels'] == ['organization'] and relabelings[14]['regex'] == 'org-(.*)' and relabelings[14]['replacement'] == '${1}' and relabelings[14]['targetLabel'] == 'organization' \
         , 'Invalid relabelings {} '.format(relabelings)
@@ -128,19 +128,20 @@ def test_service_monitor_labelling_schema_policy(servicemonitor) -> None:
     endpoints = servicemonitor['spec']['endpoints']
     for endpoint in endpoints:
         relabelings = endpoint['relabelings']
-        assert relabelings[0]['replacement'] == '' and relabelings[0]['targetLabel'] == 'cluster_id'                                                       \
-          and relabelings[1]['replacement'] == 'management_cluster' and relabelings[1]['targetLabel'] == 'cluster_type'                                    \
-          and relabelings[2]['replacement'] == 'highest' and relabelings[2]['targetLabel'] == 'service_priority'                                           \
-          and relabelings[3]['replacement'] == '' and relabelings[3]['targetLabel'] == 'provider'                                                          \
-          and relabelings[4]['replacement'] == '' and relabelings[4]['targetLabel'] == 'installation'                                                      \
-          and relabelings[5]['sourceLabels'] == ['__meta_kubernetes_namespace'] and relabelings[5]['targetLabel'] == 'namespace'                           \
-          and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[6]['targetLabel'] == 'app'          \
-          and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_instance'] and relabelings[7]['targetLabel'] == 'instance' \
-          and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[8]['targetLabel'] == 'pod'                                  \
-          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[9]['targetLabel'] == 'container'                  \
-          and relabelings[10]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[10]['targetLabel'] == 'node'                            \
-          and relabelings[11]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[11]['targetLabel'] == 'role'                          \
-          and relabelings[12]['replacement'] == '' and relabelings[12]['targetLabel'] == 'customer'                                                          \
-          and relabelings[13]['replacement'] == 'default' and relabelings[13]['targetLabel'] == 'organization'                                             \
-          and relabelings[14]['sourceLabels'] == ['organization'] and relabelings[14]['regex'] == 'org-(.*)' and relabelings[14]['replacement'] == '${1}' and relabelings[14]['targetLabel'] == 'organization' \
+        assert relabelings[0]['targetLabel'] == 'app'                                                                                                      \
+          and relabelings[1]['replacement'] == '' and relabelings[1]['targetLabel'] == 'cluster_id'                                                        \
+          and relabelings[2]['replacement'] == 'management_cluster' and relabelings[2]['targetLabel'] == 'cluster_type'                                    \
+          and relabelings[3]['replacement'] == 'highest' and relabelings[3]['targetLabel'] == 'service_priority'                                           \
+          and relabelings[4]['replacement'] == '' and relabelings[4]['targetLabel'] == 'provider'                                                          \
+          and relabelings[5]['replacement'] == '' and relabelings[5]['targetLabel'] == 'installation'                                                      \
+          and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_namespace'] and relabelings[6]['targetLabel'] == 'namespace'                           \
+          and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[7]['targetLabel'] == 'app'          \
+          and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_instance'] and relabelings[8]['targetLabel'] == 'instance' \
+          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[9]['targetLabel'] == 'pod'                                  \
+          and relabelings[10]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[10]['targetLabel'] == 'container'                \
+          and relabelings[11]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[11]['targetLabel'] == 'node'                          \
+          and relabelings[12]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[12]['targetLabel'] == 'role'                        \
+          and relabelings[13]['replacement'] == '' and relabelings[13]['targetLabel'] == 'customer'                                                        \
+          and relabelings[14]['replacement'] == 'default' and relabelings[14]['targetLabel'] == 'organization'                                             \
+          and relabelings[15]['sourceLabels'] == ['organization'] and relabelings[15]['regex'] == 'org-(.*)' and relabelings[15]['replacement'] == '${1}' and relabelings[15]['targetLabel'] == 'organization' \
         , 'Invalid relabelings {}'.format(relabelings)

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -55,8 +55,10 @@ spec:
               op: add
               value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            # - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-            #   op: add
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              # TODO: fix request.namespace templating
+              value: {"replacement": "default", "targetLabel": "organization"}
             #   value: {"replacement": "{#{ request.namespace }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -10,43 +10,55 @@ spec:
           kinds:
           - monitoring.coreos.com/v1/PodMonitor
       mutate:
-        patchStrategicMerge:
-          spec:
-            podMetricsEndpoints:
-              - relabelings:
-                  # Pod Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-                - replacement: "[[ .Values.managementCluster.name ]]"
-                  targetLabel: cluster_id
-                - replacement: "management_cluster"
-                  targetLabel: cluster_type
-                  # Since we only support management clusters, all resources are considered as highest service priority
-                - replacement: "highest"
-                  targetLabel: service_priority
-                - replacement: "[[ .Values.provider.kind ]]"
-                  targetLabel: provider
-                - replacement: "[[ .Values.managementCluster.name ]]"
-                  targetLabel: installation
-                - sourceLabels: [__meta_kubernetes_namespace]
-                  targetLabel: namespace
-                - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
-                  targetLabel: app
-                - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
-                  targetLabel: instance
-                - sourceLabels: [__meta_kubernetes_pod_name]
-                  targetLabel: pod
-                - sourceLabels: [__meta_kubernetes_pod_container_name]
-                  targetLabel: container
-                - sourceLabels: [__meta_kubernetes_pod_node_name]
-                  targetLabel: node
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  targetLabel: role
-                - replacement: "[[ .Values.managementCluster.customer ]]"
-                  targetLabel: customer
-                ## We get the organization from the namespace (org-organization_name)
-                - replacement: "{{ request.namespace }}" 
-                  targetLabel: organization
-                ## Then we remove the org prefix
-                - sourceLabels: [organization]
-                  regex: org-(.*)
-                  replacement: "${1}"
-                  targetLabel: organization
+        foreach:
+        - list: request.object.spec.podMetricsEndpoints
+          patchesJson6902: |-
+            # Pod Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "cluster_id"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
+            # Since we only support management clusters, all resources are considered as highest service priority
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "highest", "targetLabel": "service_priority"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.provider.kind ]]", "targetLabel": "provider"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
+            ## We get the organization from the namespace (org-organization_name)
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
+            ## Then we remove the org prefix
+            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -32,33 +32,33 @@ spec:
               value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+              value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
+            # - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
+            #   op: add
+            #   value: {"replacement": "{#{ request.namespace }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}
+              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -6,9 +6,10 @@ spec:
   rules:
     - name: configure-pod-monitor-labelling-schema
       match:
-        resources:
-          kinds:
-          - monitoring.coreos.com/v1/PodMonitor
+        any:
+        - resources:
+            kinds:
+            - monitoring.coreos.com/v1/PodMonitor
       mutate:
         foreach:
         - list: request.object.spec.podMetricsEndpoints
@@ -57,9 +58,7 @@ spec:
             ## We get the organization from the namespace (org-organization_name)
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              # TODO: fix request.namespace templating
-              value: {"replacement": "default", "targetLabel": "organization"}
-            #   value: {"replacement": "{#{ request.namespace }}", "targetLabel": "organization"}
+              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -6,9 +6,10 @@ spec:
   rules:
     - name: configure-service-monitor-labelling-schema
       match:
-        resources:
-          kinds:
-          - monitoring.coreos.com/v1/ServiceMonitor
+        any:
+        - resources:
+            kinds:
+            - monitoring.coreos.com/v1/ServiceMonitor
       mutate:
         foreach:
         - list: request.object.spec.endpoints
@@ -57,9 +58,7 @@ spec:
             ## We get the organization from the namespace (org-organization_name)
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              # TODO: fix request.namespace templating
-              value: {"replacement": "default", "targetLabel": "organization"}
-            #   value: {"replacement": "{#{ request.namespace }}", "targetLabel": "organization"}
+              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -10,43 +10,55 @@ spec:
           kinds:
           - monitoring.coreos.com/v1/ServiceMonitor
       mutate:
-        patchStrategicMerge:
-          spec:
-            endpoints:
-              - relabelings:
-                  # Service Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-                - replacement: "[[ .Values.managementCluster.name ]]"
-                  targetLabel: cluster_id
-                - replacement: "management_cluster"
-                  targetLabel: cluster_type
-                  # Since we only support management clusters, all resources are considered as highest service priority
-                - replacement: "highest"
-                  targetLabel: service_priority
-                - replacement: "[[ .Values.provider.kind ]]"
-                  targetLabel: provider
-                - replacement: "[[ .Values.managementCluster.name ]]"
-                  targetLabel: installation
-                - sourceLabels: [__meta_kubernetes_namespace]
-                  targetLabel: namespace
-                - sourceLabels: [ __meta_kubernetes_pod_label_app_kubernetes_io_name ]
-                  targetLabel: app
-                - sourceLabels: [ __meta_kubernetes_pod_label_app_kubernetes_io_instance ]
-                  targetLabel: instance
-                - sourceLabels: [__meta_kubernetes_pod_name]
-                  targetLabel: pod
-                - sourceLabels: [__meta_kubernetes_pod_container_name]
-                  targetLabel: container
-                - sourceLabels: [__meta_kubernetes_pod_node_name]
-                  targetLabel: node
-                - sourceLabels: [__meta_kubernetes_node_label_role]
-                  targetLabel: role
-                - replacement: "[[ .Values.managementCluster.customer ]]"
-                  targetLabel: customer
-                ## We get the organization from the namespace (org-organization_name)
-                - replacement: "{{ request.namespace }}" 
-                  targetLabel: organization
-                ## Then we remove the org prefix
-                - sourceLabels: [organization]
-                  regex: org-(.*)
-                  replacement: "${1}"
-                  targetLabel: organization
+        foreach:
+        - list: request.object.spec.endpoints
+          patchesJson6902: |-
+            # Service Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "cluster_id"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
+            # Since we only support management clusters, all resources are considered as highest service priority
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "highest", "targetLabel": "service_priority"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.provider.kind ]]", "targetLabel": "provider"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
+            ## We get the organization from the namespace (org-organization_name)
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
+            ## Then we remove the org prefix
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -55,8 +55,10 @@ spec:
               op: add
               value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            # - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-            #   op: add
+            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+              op: add
+              # TODO: fix request.namespace templating
+              value: {"replacement": "default", "targetLabel": "organization"}
             #   value: {"replacement": "{#{ request.namespace }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -32,33 +32,33 @@ spec:
               value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_namespace]", "targetLabel": "namespace"}
+              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_name]", "targetLabel": "app"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_label_app_kubernetes_io_instance]", "targetLabel": "instance"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_name]", "targetLabel": "pod"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_container_name]", "targetLabel": "container"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_pod_node_name]", "targetLabel": "node"}
+              value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[__meta_kubernetes_node_label_role]", "targetLabel": "role"}
+              value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
             ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
+            # - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
+            #   op: add
+            #   value: {"replacement": "{#{ request.namespace }}", "targetLabel": "organization"}
             ## Then we remove the org prefix
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": "[organization]", "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}
+              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}


### PR DESCRIPTION
* Changes the way we add relabelings to serviceMonitors and podMonitors. Before, it was overriding the whole endpoint setups, now it just adds required relabelings.
* upgrade kyverno version used for tests from 1.5 to 1.6
* improve documentation for local tests

Towards https://github.com/giantswarm/giantswarm/issues/22922

### Checklist

- [x] Update changelog in CHANGELOG.md.
