### PR TITLE
Update ci deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- upgrade Kyverno 1.5.1 to 1.6
+- upgrade Giantswarm CRDs v3.32.0 to v3.39.0
+
 ## [0.1.3] - 2022-08-05
 
 ## [0.1.2] - 2022-06-07

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -35,8 +35,8 @@ tilt-up: ## Start Tilt
 # If you change kyverno version here remember to change it in the Tiltfile too
 .PHONY: install-kyverno
 install-kyverno:
-	kubectl create --context kind-$(KIND_CLUSTER_NAME) -f https://raw.githubusercontent.com/kyverno/kyverno/v1.5.1/definitions/release/install.yaml
-	kubectl wait --context kind-$(KIND_CLUSTER_NAME) --for=condition=ready pod -l app=kyverno -nkyverno
+	kubectl create --context kind-$(KIND_CLUSTER_NAME) -f https://raw.githubusercontent.com/kyverno/kyverno/release-1.6/config/release/install.yaml
+	kubectl wait --context kind-$(KIND_CLUSTER_NAME) --for=condition=ready --timeout=90s pod -l app=kyverno -nkyverno
 
 .PHONY: kind-get-kubeconfig
 kind-get-kubeconfig:

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 # Giant Swarm CRDs
-kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/giantswarm/apiextensions/15836a106059cc8d201e1237adf44aec340bbab6/helm/crds-common/templates/giantswarm.yaml -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.56.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.56.2/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+kubectl create --context kind-kyverno-cluster \
+    -f https://raw.githubusercontent.com/giantswarm/apiextensions/v3.39.0/helm/crds-common/templates/giantswarm.yaml \
+    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.56.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml \
+    -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.56.2/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 
 MOCK_CREDENTIALS=$(echo -n "something" | base64)
 


### PR DESCRIPTION
Update some dependencies for CI:
- kyverno to current giantswarm used version
- giantswarm CRDs a bit more recent
- prometheus-operator CRDs were already much more recent than current giantswarm ones

### Checklist

- [x] Update changelog in CHANGELOG.md.
