### PR TITLE
Relabel only if namespace is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Relabel namespace only if it is not exported by the app.
+
 ## [0.2.0] - 2022-08-09
 
 ### Changed

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -34,7 +34,7 @@ spec:
               value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
+              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -34,7 +34,7 @@ spec:
               value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
+              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}

--- a/helm/kyverno-policies-observability/tests/ats/test_common_default.py
+++ b/helm/kyverno-policies-observability/tests/ats/test_common_default.py
@@ -107,7 +107,12 @@ def test_pod_monitor_labelling_schema_policy(podmonitor) -> None:
           and relabelings[2]['replacement'] == 'highest' and relabelings[2]['targetLabel'] == 'service_priority'                                           \
           and relabelings[3]['replacement'] == '' and relabelings[3]['targetLabel'] == 'provider'                                                          \
           and relabelings[4]['replacement'] == '' and relabelings[4]['targetLabel'] == 'installation'                                                      \
-          and relabelings[5]['sourceLabels'] == ['__meta_kubernetes_namespace'] and relabelings[5]['targetLabel'] == 'namespace'                           \
+          and relabelings[5]['sourceLabels'] == ['namespace','__meta_kubernetes_namespace'] \
+            and relabelings[5]['action'] == 'replace'                                        \
+            and relabelings[5]['separator'] == ';'                                           \
+            and relabelings[5]['regex'] == ';(.*)'                                           \
+            and relabelings[5]['replacement'] == '$1'                                        \
+            and relabelings[5]['targetLabel'] == 'namespace'                                 \
           and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[6]['targetLabel'] == 'app'          \
           and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_instance'] and relabelings[7]['targetLabel'] == 'instance' \
           and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[8]['targetLabel'] == 'pod'                                  \
@@ -134,7 +139,12 @@ def test_service_monitor_labelling_schema_policy(servicemonitor) -> None:
           and relabelings[3]['replacement'] == 'highest' and relabelings[3]['targetLabel'] == 'service_priority'                                           \
           and relabelings[4]['replacement'] == '' and relabelings[4]['targetLabel'] == 'provider'                                                          \
           and relabelings[5]['replacement'] == '' and relabelings[5]['targetLabel'] == 'installation'                                                      \
-          and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_namespace'] and relabelings[6]['targetLabel'] == 'namespace'                           \
+          and relabelings[6]['sourceLabels'] == ['namespace','__meta_kubernetes_namespace'] \
+            and relabelings[6]['action'] == 'replace'                                        \
+            and relabelings[6]['separator'] == ';'                                           \
+            and relabelings[6]['regex'] == ';(.*)'                                           \
+            and relabelings[6]['replacement'] == '$1'                                        \
+            and relabelings[6]['targetLabel'] == 'namespace'                                 \
           and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[7]['targetLabel'] == 'app'          \
           and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_instance'] and relabelings[8]['targetLabel'] == 'instance' \
           and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[9]['targetLabel'] == 'pod'                                  \

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -33,7 +33,7 @@ spec:
               value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
+              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -33,7 +33,7 @@ spec:
               value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": ["__meta_kubernetes_namespace"], "targetLabel": "namespace"}
+              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}


### PR DESCRIPTION
This PR ensures we relabel the namespace tag only if it is not exported by the exporter itself (e.g. kube-state-metrics, app-exporter). This avoids prometheus adding the exported_namespace label

### Checklist

- [x] Update changelog in CHANGELOG.md.
