### PR TITLE
cleanup podmonitor and servicemonitor relabellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Push to `capz` app collection.
 - Push to `vsphere` app collection.
 - Don't push to `openstack` app collection.
+- tests: Update dependency setuptools from v67.2.0 to v67.3.2
+- PodMonitor and ServiceMonitor: remove useless relabellings (those that are already managed by externalLabels or default relabellings).
 
 ### Fixed
 
 - Push to `cloud-director` app collection.
 - Remove deprecated `validate` step from CI.
-
-### Changed
-
-- tests: Update dependency setuptools from v67.2.0 to v67.3.2
 
 ## [0.2.2] - 2022-11-29
 

--- a/helm/kyverno-policies-observability/templates/PodMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/PodMonitor.yaml
@@ -17,52 +17,12 @@ spec:
         foreach:
         - list: request.object.spec.podMetricsEndpoints
           patchesJson6902: |-
-            # Pod Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "cluster_id"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
-            # Since we only support management clusters, all resources are considered as highest service priority
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "highest", "targetLabel": "service_priority"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.provider.kind }}", "targetLabel": "provider"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
             - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
-            ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
-            ## Then we remove the org prefix
-            - path: "/spec/podMetricsEndpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
+++ b/helm/kyverno-policies-observability/templates/ServiceMonitor.yaml
@@ -17,52 +17,9 @@ spec:
         foreach:
         - list: request.object.spec.endpoints
           patchesJson6902: |-
-            # Service Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "cluster_id"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
-            # Since we only support management clusters, all resources are considered as highest service priority
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "highest", "targetLabel": "service_priority"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.provider.kind }}", "targetLabel": "provider"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.managementCluster.name }}", "targetLabel": "installation"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
             - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
               op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
               value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ .Values.managementCluster.customer }}", "targetLabel": "customer"}
-            ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ `{{` }} request.namespace {{ `}}` }}", "targetLabel": "organization"}
-            ## Then we remove the org prefix
-            - path: "/spec/endpoints/{{ `{{` }}elementIndex{{ `}}` }}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/helm/kyverno-policies-observability/tests/ats/test_common_default.py
+++ b/helm/kyverno-policies-observability/tests/ats/test_common_default.py
@@ -96,26 +96,9 @@ def test_pod_monitor_labelling_schema_policy(podmonitor) -> None:
     endpoints = podmonitor['spec']['podMetricsEndpoints']
     for endpoint in endpoints:
         relabelings = endpoint['relabelings']
-        assert relabelings[0]['replacement'] == '' and relabelings[0]['targetLabel'] == 'cluster_id'                                                       \
-          and relabelings[1]['replacement'] == 'management_cluster' and relabelings[1]['targetLabel'] == 'cluster_type'                                    \
-          and relabelings[2]['replacement'] == 'highest' and relabelings[2]['targetLabel'] == 'service_priority'                                           \
-          and relabelings[3]['replacement'] == '' and relabelings[3]['targetLabel'] == 'provider'                                                          \
-          and relabelings[4]['replacement'] == '' and relabelings[4]['targetLabel'] == 'installation'                                                      \
-          and relabelings[5]['sourceLabels'] == ['namespace','__meta_kubernetes_namespace'] \
-            and relabelings[5]['action'] == 'replace'                                        \
-            and relabelings[5]['separator'] == ';'                                           \
-            and relabelings[5]['regex'] == ';(.*)'                                           \
-            and relabelings[5]['replacement'] == '$1'                                        \
-            and relabelings[5]['targetLabel'] == 'namespace'                                 \
-          and relabelings[6]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[6]['targetLabel'] == 'app'          \
-          and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_instance'] and relabelings[7]['targetLabel'] == 'instance' \
-          and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[8]['targetLabel'] == 'pod'                                  \
-          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[9]['targetLabel'] == 'container'                  \
-          and relabelings[10]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[10]['targetLabel'] == 'node'                          \
-          and relabelings[11]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[11]['targetLabel'] == 'role'                        \
-          and relabelings[12]['replacement'] == '' and relabelings[12]['targetLabel'] == 'customer'                                                        \
-          and relabelings[13]['replacement'] == 'default' and relabelings[13]['targetLabel'] == 'organization'                                             \
-          and relabelings[14]['sourceLabels'] == ['organization'] and relabelings[14]['regex'] == 'org-(.*)' and relabelings[14]['replacement'] == '${1}' and relabelings[14]['targetLabel'] == 'organization' \
+        assert relabelings[0]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[0]['targetLabel'] == 'app'      \
+          and relabelings[1]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[1]['targetLabel'] == 'node'                         \
+          and relabelings[2]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[2]['targetLabel'] == 'role'                       \
         , 'Invalid relabelings {} '.format(relabelings)
 
 @pytest.mark.smoke
@@ -127,25 +110,7 @@ def test_service_monitor_labelling_schema_policy(servicemonitor) -> None:
     endpoints = servicemonitor['spec']['endpoints']
     for endpoint in endpoints:
         relabelings = endpoint['relabelings']
-        assert relabelings[0]['targetLabel'] == 'app'                                                                                                      \
-          and relabelings[1]['replacement'] == '' and relabelings[1]['targetLabel'] == 'cluster_id'                                                        \
-          and relabelings[2]['replacement'] == 'management_cluster' and relabelings[2]['targetLabel'] == 'cluster_type'                                    \
-          and relabelings[3]['replacement'] == 'highest' and relabelings[3]['targetLabel'] == 'service_priority'                                           \
-          and relabelings[4]['replacement'] == '' and relabelings[4]['targetLabel'] == 'provider'                                                          \
-          and relabelings[5]['replacement'] == '' and relabelings[5]['targetLabel'] == 'installation'                                                      \
-          and relabelings[6]['sourceLabels'] == ['namespace','__meta_kubernetes_namespace'] \
-            and relabelings[6]['action'] == 'replace'                                        \
-            and relabelings[6]['separator'] == ';'                                           \
-            and relabelings[6]['regex'] == ';(.*)'                                           \
-            and relabelings[6]['replacement'] == '$1'                                        \
-            and relabelings[6]['targetLabel'] == 'namespace'                                 \
-          and relabelings[7]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[7]['targetLabel'] == 'app'          \
-          and relabelings[8]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_instance'] and relabelings[8]['targetLabel'] == 'instance' \
-          and relabelings[9]['sourceLabels'] == ['__meta_kubernetes_pod_name'] and relabelings[9]['targetLabel'] == 'pod'                                  \
-          and relabelings[10]['sourceLabels'] == ['__meta_kubernetes_pod_container_name'] and relabelings[10]['targetLabel'] == 'container'                \
-          and relabelings[11]['sourceLabels'] == ['__meta_kubernetes_pod_node_name'] and relabelings[11]['targetLabel'] == 'node'                          \
-          and relabelings[12]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[12]['targetLabel'] == 'role'                        \
-          and relabelings[13]['replacement'] == '' and relabelings[13]['targetLabel'] == 'customer'                                                        \
-          and relabelings[14]['replacement'] == 'default' and relabelings[14]['targetLabel'] == 'organization'                                             \
-          and relabelings[15]['sourceLabels'] == ['organization'] and relabelings[15]['regex'] == 'org-(.*)' and relabelings[15]['replacement'] == '${1}' and relabelings[15]['targetLabel'] == 'organization' \
+        assert relabelings[0]['targetLabel'] == 'app'                                                                                                   \
+          and relabelings[1]['sourceLabels'] == ['__meta_kubernetes_pod_label_app_kubernetes_io_name'] and relabelings[1]['targetLabel'] == 'app'       \
+          and relabelings[2]['sourceLabels'] == ['__meta_kubernetes_node_label_role'] and relabelings[2]['targetLabel'] == 'role'                       \
         , 'Invalid relabelings {}'.format(relabelings)

--- a/policies/observability/PodMonitor.yaml
+++ b/policies/observability/PodMonitor.yaml
@@ -16,52 +16,12 @@ spec:
         foreach:
         - list: request.object.spec.podMetricsEndpoints
           patchesJson6902: |-
-            # Pod Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "cluster_id"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
-            # Since we only support management clusters, all resources are considered as highest service priority
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "highest", "targetLabel": "service_priority"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.provider.kind ]]", "targetLabel": "provider"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
             - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
-            ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
-            ## Then we remove the org prefix
-            - path: "/spec/podMetricsEndpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}

--- a/policies/observability/ServiceMonitor.yaml
+++ b/policies/observability/ServiceMonitor.yaml
@@ -16,52 +16,9 @@ spec:
         foreach:
         - list: request.object.spec.endpoints
           patchesJson6902: |-
-            # Service Monitors are currently only supported on management clusters, so we can enforce the cluster_id and cluster_type.
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "cluster_id"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "management_cluster", "targetLabel": "cluster_type"}
-            # Since we only support management clusters, all resources are considered as highest service priority
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "highest", "targetLabel": "service_priority"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.provider.kind ]]", "targetLabel": "provider"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.managementCluster.name ]]", "targetLabel": "installation"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["namespace", "__meta_kubernetes_namespace"], "action": "replace", "separator": ";", "regex": ";(.*)", "replacement": "$1", "targetLabel": "namespace"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
               value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_name"], "targetLabel": "app"}
             - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
               op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"], "targetLabel": "instance"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_name"], "targetLabel": "pod"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_container_name"], "targetLabel": "container"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["__meta_kubernetes_pod_node_name"], "targetLabel": "node"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
               value: {"sourceLabels": ["__meta_kubernetes_node_label_role"], "targetLabel": "role"}
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "[[ .Values.managementCluster.customer ]]", "targetLabel": "customer"}
-            ## We get the organization from the namespace (org-organization_name)
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"replacement": "{{ request.namespace }}", "targetLabel": "organization"}
-            ## Then we remove the org prefix
-            - path: "/spec/endpoints/{{elementIndex}}/relabelings/-1"
-              op: add
-              value: {"sourceLabels": ["organization"], "regex": "org-(.*)", "replacement": "${1}", "targetLabel": "organization"}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27846

We noticed some relabellings are useless:
- some are automatically added by prometheus-operator
- some are added as external labels

On top of that, the adding of too many relabellings each time kyverno policy is applied clutters the servicemonitors, and sometimes prevents apps upgrades.

So I did some cleanup, and only kept those that under discussion, for the moment.

### Checklist

- [x] Update changelog in CHANGELOG.md.
