### PR TITLE
Let all_pipelines alerts go through

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,37 +129,11 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
-          name: push-kyverno-policies-observability-to-azure-app-collection
-          context: architect
-          app_name: "kyverno-policies-observability"
-          app_namespace: "giantswarm"
-          app_collection_repo: "azure-app-collection"
-          requires:
-            - push-kyverno-policies-observability-to-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - architect/push-to-app-collection:
           name: push-kyverno-policies-observability-to-capa-app-collection
           context: architect
           app_name: "kyverno-policies-observability"
           app_namespace: "giantswarm"
           app_collection_repo: "capa-app-collection"
-          requires:
-            - push-kyverno-policies-observability-to-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - architect/push-to-app-collection:
-          name: push-kyverno-policies-observability-to-kvm-app-collection
-          context: architect
-          app_name: "kyverno-policies-observability"
-          app_namespace: "giantswarm"
-          app_collection_repo: "kvm-app-collection"
           requires:
             - push-kyverno-policies-observability-to-catalog
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `all_pipelines` label to the silence kyverno policy to let some custom alerts through.
+
 ## [0.3.0] - 2023-10-09
 
 ### Changed

--- a/helm/kyverno-policies-observability/templates/Silence.yaml
+++ b/helm/kyverno-policies-observability/templates/Silence.yaml
@@ -2,12 +2,12 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: always-allow-heartbeat
+  name: always-allow-heartbeats-and-all-pipelines-alerts
   labels:
     {{ include "labels.common" . | nindent 4 }}
 spec:
   rules:
-    - name: always-allow-heartbeat
+    - name: always-allow-heartbeats-and-all-pipelines-alerts
       match:
         resources:
           kinds:
@@ -17,3 +17,6 @@ spec:
           - path: "/spec/matchers/-"
             op: add
             value: {"name": "alertname", "value": "Heartbeat", "isEqual": false, "isRegex": false}
+          - path: "/spec/matchers/-"
+            op: add
+            value: {"name": "all_pipelines", "value": "true", "isEqual": false, "isRegex": false}

--- a/policies/observability/Silence.yaml
+++ b/policies/observability/Silence.yaml
@@ -1,12 +1,12 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: always-allow-heartbeat
+  name: always-allow-heartbeats-and-all-pipelines-alerts
   labels:
     [[ include "labels.common" . | nindent 4 ]]
 spec:
   rules:
-    - name: always-allow-heartbeat
+    - name: always-allow-heartbeats-and-all-pipelines-alerts
       match:
         resources:
           kinds:
@@ -16,3 +16,6 @@ spec:
           - path: "/spec/matchers/-"
             op: add
             value: {"name": "alertname", "value": "Heartbeat", "isEqual": false, "isRegex": false}
+          - path: "/spec/matchers/-"
+            op: add
+            value: {"name": "all_pipelines", "value": "true", "isEqual": false, "isRegex": false}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30124

This PR changes the allow-heartbeat silence policy to ensure we also let through alerts that have the `all_pipelines: true` label. This label will let some alert through for test installations to avoid issues like cloud cost going crazy

### Checklist

- [x] Update changelog in CHANGELOG.md.
