### PR TITLE
fix: idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow a `Silence` to opt out of the injected `all_pipelines` matcher by setting the `silence.application.giantswarm.io/force-all: "true"` annotation. Applies to both the `monitoring.giantswarm.io/v1alpha1` and `observability.giantswarm.io/v1alpha2` Silence APIs.
 
+### Fixed
+
+- Stop duplicating the injected `Heartbeat` and `all_pipelines` matchers. The mutation also runs on `UPDATE` (e.g. when the silence-operator adds its finalizer), and the `op: add` patch previously appended a copy every time. Each rule now only adds its matcher when it is not already present.
+
 ### Changed
 
 - Change team annotation in `Chart.yaml` to OpenContainers format (`io.giantswarm.application.team`).

--- a/helm/kyverno-policies-observability/templates/Silence.yaml
+++ b/helm/kyverno-policies-observability/templates/Silence.yaml
@@ -13,6 +13,12 @@ spec:
         resources:
           kinds:
           - observability.giantswarm.io/v1alpha2/Silence
+      preconditions:
+        # Idempotency: only add the Heartbeat matcher if it is absent.
+        all:
+        - key: "{{ `{{` }} request.object.spec.matchers[?name=='alertname' && value=='Heartbeat'] || `[]` | length(@) {{ `}}` }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"
@@ -24,12 +30,16 @@ spec:
           kinds:
           - observability.giantswarm.io/v1alpha2/Silence
       preconditions:
+        all:
         # Skip the all_pipelines matcher when the Silence opts out via the
         # silence.application.giantswarm.io/force-all annotation set to "true".
-        all:
         - key: "{{ `{{` }} request.object.metadata.annotations.\"silence.application.giantswarm.io/force-all\" || '' {{ `}}` }}"
           operator: NotEquals
           value: "true"
+        # Idempotency: only add the all_pipelines matcher if it is absent.
+        - key: "{{ `{{` }} request.object.spec.matchers[?name=='all_pipelines'] || `[]` | length(@) {{ `}}` }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"
@@ -41,6 +51,12 @@ spec:
         resources:
           kinds:
           - monitoring.giantswarm.io/v1alpha1/Silence
+      preconditions:
+        # Idempotency: only add the Heartbeat matcher if it is absent.
+        all:
+        - key: "{{ `{{` }} request.object.spec.matchers[?name=='alertname' && value=='Heartbeat'] || `[]` | length(@) {{ `}}` }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"
@@ -52,12 +68,16 @@ spec:
           kinds:
           - monitoring.giantswarm.io/v1alpha1/Silence
       preconditions:
+        all:
         # Skip the all_pipelines matcher when the Silence opts out via the
         # silence.application.giantswarm.io/force-all annotation set to "true".
-        all:
         - key: "{{ `{{` }} request.object.metadata.annotations.\"silence.application.giantswarm.io/force-all\" || '' {{ `}}` }}"
           operator: NotEquals
           value: "true"
+        # Idempotency: only add the all_pipelines matcher if it is absent.
+        - key: "{{ `{{` }} request.object.spec.matchers[?name=='all_pipelines'] || `[]` | length(@) {{ `}}` }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"

--- a/policies/observability/Silence.yaml
+++ b/policies/observability/Silence.yaml
@@ -12,6 +12,12 @@ spec:
         resources:
           kinds:
           - observability.giantswarm.io/v1alpha2/Silence
+      preconditions:
+        # Idempotency: only add the Heartbeat matcher if it is absent.
+        all:
+        - key: "{{ request.object.spec.matchers[?name=='alertname' && value=='Heartbeat'] || `[]` | length(@) }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"
@@ -23,12 +29,16 @@ spec:
           kinds:
           - observability.giantswarm.io/v1alpha2/Silence
       preconditions:
+        all:
         # Skip the all_pipelines matcher when the Silence opts out via the
         # silence.application.giantswarm.io/force-all annotation set to "true".
-        all:
         - key: "{{ request.object.metadata.annotations.\"silence.application.giantswarm.io/force-all\" || '' }}"
           operator: NotEquals
           value: "true"
+        # Idempotency: only add the all_pipelines matcher if it is absent.
+        - key: "{{ request.object.spec.matchers[?name=='all_pipelines'] || `[]` | length(@) }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"
@@ -40,6 +50,12 @@ spec:
         resources:
           kinds:
           - monitoring.giantswarm.io/v1alpha1/Silence
+      preconditions:
+        # Idempotency: only add the Heartbeat matcher if it is absent.
+        all:
+        - key: "{{ request.object.spec.matchers[?name=='alertname' && value=='Heartbeat'] || `[]` | length(@) }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"
@@ -51,12 +67,16 @@ spec:
           kinds:
           - monitoring.giantswarm.io/v1alpha1/Silence
       preconditions:
+        all:
         # Skip the all_pipelines matcher when the Silence opts out via the
         # silence.application.giantswarm.io/force-all annotation set to "true".
-        all:
         - key: "{{ request.object.metadata.annotations.\"silence.application.giantswarm.io/force-all\" || '' }}"
           operator: NotEquals
           value: "true"
+        # Idempotency: only add the all_pipelines matcher if it is absent.
+        - key: "{{ request.object.spec.matchers[?name=='all_pipelines'] || `[]` | length(@) }}"
+          operator: Equals
+          value: 0
       mutate:
         patchesJson6902: |-
           - path: "/spec/matchers/-"

--- a/tests/chainsaw/always-allow-heartbeats-and-all-pipelines-alerts-v1alpha1/chainsaw-test.yaml
+++ b/tests/chainsaw/always-allow-heartbeats-and-all-pipelines-alerts-v1alpha1/chainsaw-test.yaml
@@ -60,6 +60,31 @@ spec:
               isRegex: false
               isEqual: false
 
+  # Idempotency: the policy also runs on UPDATE (e.g. the silence-operator
+  # adding its finalizer). Trigger an update by adding a label and assert the
+  # injected matchers are NOT duplicated — exactly one of each must remain.
+  - name: update-silence-v1alpha1-and-assert-no-duplicate-matchers
+    try:
+    - patch:
+        resource:
+          apiVersion: monitoring.giantswarm.io/v1alpha1
+          kind: Silence
+          metadata:
+            name: chainsaw-test-silence-v1alpha1
+            labels:
+              trigger-update: "1"
+    - assert:
+        timeout: 30s
+        template: true
+        resource:
+          apiVersion: monitoring.giantswarm.io/v1alpha1
+          kind: Silence
+          metadata:
+            name: chainsaw-test-silence-v1alpha1
+          spec:
+            (length(matchers[?name=='alertname' && value=='Heartbeat'])): 1
+            (length(matchers[?name=='all_pipelines'])): 1
+
   # Opt-out via annotation: when the Silence carries the
   # silence.application.giantswarm.io/force-all=true annotation, the policy
   # must still add the Heartbeat matcher but must NOT add the all_pipelines

--- a/tests/chainsaw/always-allow-heartbeats-and-all-pipelines-alerts-v1alpha2/chainsaw-test.yaml
+++ b/tests/chainsaw/always-allow-heartbeats-and-all-pipelines-alerts-v1alpha2/chainsaw-test.yaml
@@ -55,6 +55,31 @@ spec:
               value: "true"
               matchType: "!="
 
+  # Idempotency: the policy also runs on UPDATE (e.g. the silence-operator
+  # adding its finalizer). Trigger an update by adding a label and assert the
+  # injected matchers are NOT duplicated — exactly one of each must remain.
+  - name: update-silence-v1alpha2-and-assert-no-duplicate-matchers
+    try:
+    - patch:
+        resource:
+          apiVersion: observability.giantswarm.io/v1alpha2
+          kind: Silence
+          metadata:
+            name: test-silence-v1alpha2
+            labels:
+              trigger-update: "1"
+    - assert:
+        timeout: 30s
+        template: true
+        resource:
+          apiVersion: observability.giantswarm.io/v1alpha2
+          kind: Silence
+          metadata:
+            name: test-silence-v1alpha2
+          spec:
+            (length(matchers[?name=='alertname' && value=='Heartbeat'])): 1
+            (length(matchers[?name=='all_pipelines'])): 1
+
   # Opt-out via annotation: when the Silence carries the
   # silence.application.giantswarm.io/force-all=true annotation, the policy
   # must still add the Heartbeat matcher but must NOT add the all_pipelines


### PR DESCRIPTION
Stop re-adding the exceptions each time the silences are updated (like when the observability-operator adds its finalizer).

### Checklist

- [x] Update changelog in CHANGELOG.md.
